### PR TITLE
Added support for Passthrough Signs

### DIFF
--- a/src/main/java/com/girafi/passthroughsigns/api/IPassable.java
+++ b/src/main/java/com/girafi/passthroughsigns/api/IPassable.java
@@ -1,0 +1,30 @@
+package com.girafi.passthroughsigns.api;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public interface IPassable {
+
+    /**
+     * Return true if this block/entity should be passable.
+     *
+     * @param world the world
+     * @param pos   the position of the block/entity
+     * @param type  the EnumPassableType for the block/entity
+     * @return whether the block/entity can be passed or not
+     */
+    boolean canBePassed(World world, BlockPos pos, EnumPassableType type);
+
+    enum EnumPassableType {
+
+        /**
+         * For blocks similiar to wall signs & banners.
+         */
+        WALL_BLOCK,
+
+        /**
+         * For entities similar to item frames, paintings etc.
+         */
+        HANGING_ENTITY
+    }
+}

--- a/src/main/java/gory_moon/moarsigns/blocks/BlockMoarSignWall.java
+++ b/src/main/java/gory_moon/moarsigns/blocks/BlockMoarSignWall.java
@@ -1,5 +1,6 @@
 package gory_moon.moarsigns.blocks;
 
+import com.girafi.passthroughsigns.api.IPassable;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -11,8 +12,10 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
 
-public class BlockMoarSignWall extends BlockMoarSign {
+@Optional.Interface(modid = "passthroughsigns", iface = "com.girafi.passthroughsigns.api.IPassable")
+public class BlockMoarSignWall extends BlockMoarSign implements IPassable {
 
     public static final PropertyDirection FACING = PropertyDirection.create("facing");
 
@@ -141,4 +144,9 @@ public class BlockMoarSignWall extends BlockMoarSign {
         }
     }
 
+    @Override
+    @Optional.Method(modid = "passthroughsigns")
+    public boolean canBePassed(World world, BlockPos pos, EnumPassableType type) {
+        return type == EnumPassableType.WALL_BLOCK;
+    }
 }


### PR DESCRIPTION
As requested in https://github.com/dmillerw/PassthroughSigns/issues/1, this PR makes it possible to right click any wall signs from Moar Signs attached to any container and it will open the container. Of course only when both Moar Signs and Passthrough Signs is present.
